### PR TITLE
Accept typeahead options via data attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,10 @@ Meteor.typeahead = function(element, source) {
 	if (Array.isArray(datasets)) {
 		$e.typeahead.apply($e, [null].concat(datasets));
 	} else {
-		$e.typeahead(null, datasets);
+		var highlight = Boolean($e.data('highlight')) || false;
+		var hint = Boolean($e.data('hint')) || false;
+		var minLength = parseInt($e.data('min-length')) || 1;
+		$e.typeahead({highlight: highlight, hint: hint, minLength: minLength}, datasets);
 	}
 
 	// fix to apply bootstrap form-control to tt-hint


### PR DESCRIPTION
This allows to pass the supported three options (highlight, hint,
minLength) to be passed into the typeahead function. They have to be
passed via a data-attributes (e.g. data-highlight=‚true’).
