### PR TITLE
METEOR@0.9.4 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -186,7 +186,7 @@ function resolve_template_function(element, name) {
 		if (!view) {
 			return [];
 		}
-		fn = view.template && view.template[name];
+		fn = view.template && Blaze._getTemplateHelper(view.template, name);
 	}
 
 	if (!$.isFunction(fn)) {


### PR DESCRIPTION
Using Blaze new getTemplateHelper.
- getTemplateHelper still supports old-style helpers. Deprecation message will be shown.
- Version check for meteor < 0.9.4 should be added
