### PR TITLE
Allow to activate autoselect option via data attribute.

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -57,6 +57,8 @@ Activates typeahead behavior for all elements matched by given CSS `selector`. `
 
 * `data-min-length` – The minimum character length needed before suggestions start getting rendered. Defaults to `1`.
 
+* `data-autoselect` – If `true`, the typeahead will select the first option when press enter key. Defaults to `false`.
+
 #### Events
 
 Using data attributes you could specify handlers for corresponding typeahead `opened`, `closed`, `selected`, `autocompleted` events. Value of data attribute is name of template helper function to be used as event handler.

--- a/index.js
+++ b/index.js
@@ -28,12 +28,14 @@ Meteor.typeahead = function(element, source) {
 	// other known options passed via data attributes
 	var highlight = Boolean($e.data('highlight')) || false;
 	var hint = Boolean($e.data('hint')) || false;
+	var autoselect = Boolean($e.data('autoselect')) || false;
 	var minLength = get_min_length($e);
 
 	options = $.extend(options, {
 		highlight: highlight,
 		hint: hint,
-		minLength: minLength
+		minLength: minLength,
+		autoselect: autoselect
 	});
 
 	var instance;


### PR DESCRIPTION
I need this option to be enabled to automatically select the first option in the suggestions list when pressing enter. Here the evolution of this feature: https://github.com/twitter/typeahead.js/issues/32