### PR TITLE
Fixes multi-inject bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,14 +100,28 @@ Meteor.typeahead.inject = function(selector) {
 	if (!selector) {
 		selector = '.typeahead';
 	}
-	$(selector).each(function(i,e) {
-		try {
-			Meteor.typeahead(e);
-		} catch (err) {
-			console.log(err);
-		}
-	});
+
+	// See if we have a template instance to reference
+	var template = Template.instance();
+	if (!template) {
+		// If we don't, just init on the entire DOM
+		$(selector).each(init_typeahead);
+	} else {
+		// Otherwise just init this template's typeaheads
+		template.$(selector).each(init_typeahead);
+	}
 };
+
+function init_typeahead(index, element) {
+	try {
+		if (element.data('ttTypeahead') == null) {
+			Meteor.typeahead(element);
+		}
+	} catch (err) {
+		console.log(err);
+		return;
+	}
+}
 
 function resolve_datasets($e, source) {
 	var element = $e[0];


### PR DESCRIPTION
No longer will calling `Meteor.typeahead.inject()` twice on the same element cause it to stop working. It simply ignores the second initialization.
Also, if inject is called from within a template instance, it will only search that template's DOM nodes for typeahead elements to be injected. Otherwise, it will search the entire DOM structure, as it did before.