### PR TITLE
Maintain Template.instance() scope in autorun

### DIFF
--- a/index.js
+++ b/index.js
@@ -376,7 +376,12 @@ function make_bloodhound(dataset) {
 		if ($.isFunction(dataset.local) && dataset.local.length === 0) {
 			// update data source on changing deps of local function
 			// TODO find better (functional) way to do that
-			Template.instance().autorun(function() {
+			if(Template.instance() !== null)
+				autorun_context = Template.instance();
+			else
+				autorun_context = Tracker;
+
+			autorun_context.autorun(function() {
 				engine = new Bloodhound(options);
 				engine.initialize();
 			});

--- a/index.js
+++ b/index.js
@@ -376,7 +376,7 @@ function make_bloodhound(dataset) {
 		if ($.isFunction(dataset.local) && dataset.local.length === 0) {
 			// update data source on changing deps of local function
 			// TODO find better (functional) way to do that
-			Deps.autorun(function() {
+			Template.instance().autorun(function() {
 				engine = new Bloodhound(options);
 				engine.initialize();
 			});


### PR DESCRIPTION
Changed the `Deps.autorun` call to use `Template.instance().autorun` so that future calls to helper functions inherit the proper scope.