### PR TITLE
Template helper called without Template context

### DIFF
--- a/index.js
+++ b/index.js
@@ -277,7 +277,7 @@ function resolve_template_function(element, name) {
 	}
 
 	var fn = Blaze._getTemplateHelper(view.template, name);
-	return $.isFunction(fn) ? fn.bind(view.template) : null;
+	return $.isFunction(fn) ? Meteor.wrapAsync(fn, view._templateInstance.data) : null;
 }
 
 // Returns HTML template function that generates HTML string using data from suggestion item.

--- a/index.js
+++ b/index.js
@@ -277,7 +277,22 @@ function resolve_template_function(element, name) {
 	}
 
 	var fn = Blaze._getTemplateHelper(view.template, name);
-	return $.isFunction(fn) ? Meteor.wrapAsync(fn, view._templateInstance.data) : null;
+
+	if($.isFunction(fn)) {
+		// wrap their function to setup the Template.instance() stuff
+		// define at least one arg to avoid fn being considered a local dataset
+		return function(a) {
+			var args = Array.prototype.slice.call(arguments);
+			// internal function which sets the instance before calling our function
+			Template._withTemplateInstanceFunc(
+				function() { return view.templateInstance(); },
+				function() {return fn.apply(view._templateInstance.data, args);}
+			);
+		};
+	}
+
+  // else not a function...
+	return null;
 }
 
 // Returns HTML template function that generates HTML string using data from suggestion item.


### PR DESCRIPTION
I setup the Server Side Search example and want to access `Template.instance()` and `Template.parentData()` in the helper referenced by `data-source`.

The problem is, `Template.instance()` returns `null`. And, the `this` is a `Dataset` object. 
 
I looked through the Dataset object and didn't find any objects in there to access what I want.

Where is the code which calls the helper function? I scanned the source and it wasn't obvious where that's happening. I'm wondering if it's possible to alter that to use `call()` and give it the Template context instead.
