### PR TITLE
Allows datasources to be resolved from parent views

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,8 +276,21 @@ function resolve_template_function(element, name) {
 		return null;
 	}
 
-	var fn = Blaze._getTemplateHelper(view.template, name);
-	if (!$.isFunction(fn)) {
+	function getHelperFromViewOrParent(view, name){
+		if (!view){
+			return null;
+		}
+		if (view.template){
+			var fn = Blaze._getTemplateHelper(view.template, name);
+			if ( $.isFunction(fn) ){
+				return fn;
+			}
+		}
+		return getHelperFromViewOrParent(view.parentView, name);
+	};
+
+	var fn = getHelperFromViewOrParent(view, name);
+	if (!fn) {
 		return null;
 	}
 


### PR DESCRIPTION
Allows datasources to be resolved from the current view or a parent view.  The first matching function will be selected when walking up the view chain.  This allows typeahead to be used with other packages that wrap inputs in their own templates, such as aldeed:autoform.

This should fix Issue #84, I think, but I haven't tested against their exact issue.  It fixes my issue (no bug submitted) with autoform.  