### PR TITLE
Remove autocomplete attribute.

### DIFF
--- a/typeahead.bundle.js
+++ b/typeahead.bundle.js
@@ -2396,7 +2396,6 @@
         }
         function buildHintFromInput($input, www) {
             return $input.clone().addClass(www.classes.hint).removeData().css(www.css.hint).css(getBackgroundStyles($input)).prop("readonly", true).removeAttr("id name placeholder required").attr({
-                spellcheck: "false",
                 tabindex: -1
             });
         }
@@ -2407,9 +2406,7 @@
                 spellcheck: $input.attr("spellcheck"),
                 style: $input.attr("style")
             });
-            $input.addClass(www.classes.input).attr({
-                spellcheck: "false"
-            });
+            $input.addClass(www.classes.input);
             try {
                 !$input.attr("dir") && $input.attr("dir", "auto");
             } catch (e) {}

--- a/typeahead.bundle.js
+++ b/typeahead.bundle.js
@@ -2396,7 +2396,6 @@
         }
         function buildHintFromInput($input, www) {
             return $input.clone().addClass(www.classes.hint).removeData().css(www.css.hint).css(getBackgroundStyles($input)).prop("readonly", true).removeAttr("id name placeholder required").attr({
-                autocomplete: "false",
                 spellcheck: "false",
                 tabindex: -1
             });
@@ -2409,7 +2408,6 @@
                 style: $input.attr("style")
             });
             $input.addClass(www.classes.input).attr({
-                autocomplete: "false",
                 spellcheck: "false"
             });
             try {


### PR DESCRIPTION
As discussed in https://github.com/sergeyt/meteor-typeahead/issues/97 , autocomplete="false" is not working for Chrome. Needs to be setup through application.