### PR TITLE
Add support for multiple value keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -430,6 +430,11 @@ function make_bloodhound(dataset) {
 	var engine;
 
 	if (need_bloodhound) {
+		// Supports multiple fields passed, deliniated by spaces
+		if (dataset.valueKey.indexOf(" ") !== -1) {
+			dataset.valueKey = dataset.valueKey.split(" ");
+		};
+
 		var options = $.extend({}, dataset, {
 			// TODO support custom tokenizers
 			datumTokenizer: Bloodhound.tokenizers.obj.whitespace(dataset.valueKey),


### PR DESCRIPTION
Simply splits the passed string for value keys on space deliniation to pass as bloodhound.tokenizer parameter.